### PR TITLE
[RB-1640] Add config option to invert base_link to map tf

### DIFF
--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -291,12 +291,21 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
 
         tf_broadcaster_.sendTransform(stamped_transforms);
       } else {
-        stamped_transform.header.frame_id = node_options_.map_frame;
-        stamped_transform.child_frame_id =
+        if(node_options_.invert_map_frame_to_published_frame_tf) {
+          // Changing the frame and child_frame_id so that base_link->map_cartographer frame is published.
+          stamped_transform.header.frame_id = trajectory_data.trajectory_options.published_frame;
+          stamped_transform.child_frame_id = node_options_.map_frame;
+          Rigid3d rigid_tf = (tracking_to_map * (*trajectory_data.published_to_tracking)).inverse();
+          stamped_transform.transform = ToGeometryMsgTransform(rigid_tf);
+          tf_broadcaster_.sendTransform(stamped_transform);
+        } else {
+          stamped_transform.header.frame_id = node_options_.map_frame;
+          stamped_transform.child_frame_id =
             trajectory_data.trajectory_options.published_frame;
-        stamped_transform.transform = ToGeometryMsgTransform(
+          stamped_transform.transform = ToGeometryMsgTransform(
             tracking_to_map * (*trajectory_data.published_to_tracking));
-        tf_broadcaster_.sendTransform(stamped_transform);
+          tf_broadcaster_.sendTransform(stamped_transform);
+        }
       }
     }
   }

--- a/cartographer_ros/cartographer_ros/node_options.cc
+++ b/cartographer_ros/cartographer_ros/node_options.cc
@@ -40,6 +40,10 @@ NodeOptions CreateNodeOptions(
       lua_parameter_dictionary->GetDouble("pose_publish_period_sec");
   options.trajectory_publish_period_sec =
       lua_parameter_dictionary->GetDouble("trajectory_publish_period_sec");
+  if (lua_parameter_dictionary->HasKey("invert_map_frame_to_published_frame_tf")){
+    options.invert_map_frame_to_published_frame_tf =
+        lua_parameter_dictionary->GetBool("invert_map_frame_to_published_frame_tf");
+  }
   if (lua_parameter_dictionary->HasKey("use_pose_extrapolator")) {
     options.use_pose_extrapolator =
         lua_parameter_dictionary->GetBool("use_pose_extrapolator");

--- a/cartographer_ros/cartographer_ros/node_options.h
+++ b/cartographer_ros/cartographer_ros/node_options.h
@@ -36,6 +36,7 @@ struct NodeOptions {
   double pose_publish_period_sec;
   double trajectory_publish_period_sec;
   bool use_pose_extrapolator = true;
+  bool invert_map_frame_to_published_frame_tf = false;
 };
 
 NodeOptions CreateNodeOptions(


### PR DESCRIPTION
2 nodes cannot simultaneously publish map_frame.
If AMCL is running them AMCL provides map->odom frame. In order to run both AMCL and cartographer in the same environment provide a configuration parameter which when set to true will invert map_cartographer->base_link tf.

Testing:
invert_map_frame_to_published_frame_tf = true,
AMCL provides map->odom, cartographer provides base_link->map_cartographer.
[frames_with_amcl.pdf](https://github.com/BossaNova/cartographer_ros/files/3506757/frames_with_amcl.pdf)
 When AMCL is not running, we can set this parameter to false.
invert_map_frame_to_published_frame_tf = false,
cartographer provides map -> base_link.
[frames_without_amcl.pdf](https://github.com/BossaNova/cartographer_ros/files/3506762/frames_without_amcl.pdf)


